### PR TITLE
build: add ncc build script

### DIFF
--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -1,22 +1,22 @@
-name: 'Semantic Version Bump'
-description: 'Bumps the package.json version according to semver, with beta components, and pushes it back to the repository'
+name: Semantic Version Bump
+description: Bumps the package.json version according to semver, with beta components, and pushes it back to the repository
 
 inputs:
   path:
-    description: 'Path to package'
+    description: Path to package
     required: true
     default: './'
   prerelease:
-    description: 'Bump to a prerelease version. Uses the string value as the prerelease id e.g. 1.0.0-<prerelease>.2. If empty, does not bump to a prerelease.'
+    description: Bump to a prerelease version. Uses the string value as the prerelease id e.g. 1.0.0-<prerelease>.2. If empty, does not bump to a prerelease.
     required: true
     default: ''
 
 outputs:
   previous:
-    description: 'The previous semantic version.'
+    description: The previous semantic version.
   next:
-    description: 'The next semantic version.'
+    description: The next semantic version.
 
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: node12
+  main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1222,17 +1222,6 @@
         "graceful-fs": "^4.1.3",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -1708,6 +1697,12 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "@vercel/ncc": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.27.0.tgz",
+      "integrity": "sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -1809,6 +1804,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -3109,6 +3110,12 @@
         }
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -3311,6 +3318,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -8196,6 +8209,15 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -9331,6 +9353,20 @@
         }
       }
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -9812,6 +9848,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Shabad OS cross-repository actions",
   "scripts": {
+    "build": "ts-node scripts/build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --color",
     "test": "jest --coverage --color --runInBand"
   },
@@ -36,6 +37,7 @@
     "@types/semver": "^7.3.4",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
+    "@vercel/ncc": "^0.27.0",
     "eslint": "^7.9.0",
     "eslint-config-airbnb-typescript": "^10.0.0",
     "eslint-plugin-import": "^2.22.0",

--- a/publish-branch/action.yml
+++ b/publish-branch/action.yml
@@ -1,21 +1,21 @@
-name: 'Publish Release Branch'
-description: 'Publishes the current working directory as a release branch, using the current git tag'
+name: Publish Release Branch
+description: Publishes the current working directory as a release branch, using the current git tag
 
 inputs:
   fixed_branch:
-    description: 'If set, a fixed branch to publish to, such as gh-pages'
+    description: If set, a fixed branch to publish to, such as gh-pages
     required: false
 
   release_branch_prefix:
-    description: 'The prefix for any release branches'
+    description: The prefix for any release branches
     required: true
-    default: 'release'
+    default: release
 
   gitignore:
-    description: 'Contents of replacement .gitignore file, in order to commit build artifacts'
+    description: Contents of replacement .gitignore file, in order to commit build artifacts
     default: ''
     required: false
 
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: node12
+  main: dist/index.js

--- a/publish-github/action.yml
+++ b/publish-github/action.yml
@@ -1,34 +1,34 @@
-name: 'Publish GitHub Release'
-description: 'Pushes any commits back to the main branch and creates a GitHub release with the latest tag'
+name: Publish GitHub Release
+description: Pushes any commits back to the main branch and creates a GitHub release with the latest tag
 
 inputs:
   main_branch:
-    description: 'The name of the main branch'
+    description: The name of the main branch
     required: true
-    default: 'main'
+    default: main
 
   body_path:
-    description: 'The path to the file to populate the release body with'
+    description: The path to the file to populate the release body with
     required: true
-    default: 'CHANGELOG.md'
+    default: CHANGELOG.md
 
   asset_paths:
-    description: 'Newline seperated list of globs/path to assets to be uploaded'
+    description: Newline seperated list of globs/path to assets to be uploaded
     required: false
 
 outputs:
   id:
-    description: 'The release id'
+    description: The release id
 
   upload_url:
-    description: 'The URL to upload assets to the release'
+    description: The URL to upload assets to the release
 
   html_url:
-    description: 'The URL to the release'
+    description: The URL to the release
 
   assets_url:
-    description: 'The URL to the release assets'
+    description: The URL to the release assets
 
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: node12
+  main: dist/index.js

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,19 @@
+import { execSync } from 'child_process'
+import { readdirSync } from 'fs'
+
+const actionDirectories = readdirSync( '.', { withFileTypes: true } )
+  .filter( ( directory ) => directory.isDirectory() )
+  .filter( ( directory ) => {
+    const files = readdirSync( directory.name )
+
+    return files.includes( 'action.yml' ) && files.includes( 'index.ts' )
+  } )
+  .map( ( directory ) => directory.name )
+
+console.log( `Building ${actionDirectories.length} actions\n` )
+
+actionDirectories.forEach( ( name ) => {
+  console.log( `Building ${name}` )
+
+  execSync( `ncc build ${name}/index.ts -o ${name}/dist` )
+} )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "lib": ["es6"],
+    "target": "ES2019",
+    "module": "CommonJS",
+    "lib": ["ES6"],
     "allowJs": true,
     "esModuleInterop": true,
-    "noEmit": true,
     "isolatedModules": true,
     "strict": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
-  }
+    "emitDecoratorMetadata": true,
+    "outDir": "dist"
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts", "test"]
 }


### PR DESCRIPTION
### Summary of PR

Build the GitHub actions with `@vercel/ncc`, compiling them into a single `dist/index.js` file.

### Tests for unexpected behavior
- Have run successful pipelines

### Time spent on PR
Many, many hours (due to the work required to make `ncc` play nicely with the dynamic requiring done in `conventional-changelog-preset-loader`

