### PR TITLE
revert: fix(publish-github): only acquire version via annotated tags, not lightweight

### DIFF
--- a/publish-github/index.ts
+++ b/publish-github/index.ts
@@ -20,7 +20,7 @@ const run = async () => {
   const octokit = getOctokit( token )
 
   // Get latest version through tag
-  const version = ( await ( git.raw( 'describe', '--abbrev=0', '--tags' ) ) ).trim()
+  const version = ( await ( git.raw( 'describe', '--abbrev=0' ) ) ).trim()
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const { id, upload_url, html_url, assets_url } = await createRelease( { octokit, version } )


### PR DESCRIPTION
… 

This reverts commit f6c444352ac95b3fc539e1f0a70832a5abe0c8f1.

### Summary of PR
brief_summary_plz

### Tests for unexpected behavior
- none_whatsoever

### Time spent on PR
nine_thousand_years

### Linked issues
Fix #

<!-- Thank you for your PR! If you're still working, please mark this PR as a draft. -->
<!-- If you're ready to merge, be sure to do the following: -->
<!-- 1) Add reviewer(s) -->
<!-- 2) Add assignee(s) -->
<!-- 3) Confirm PR title conforms with git commit guidelines (as we will be squashing the PR when merging) -->
