### PR TITLE
Fix failing CI/CD tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: c-hive/gha-npm-cache@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
       - run: npm install
       - run: npm run lint
 
@@ -22,7 +25,10 @@ jobs:
           user: Shabad OS Bot
           email: team@shabados.com
       - uses: actions/checkout@v2
-      - uses: c-hive/gha-npm-cache@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
       - run: npm install
       - run: npm run test
 
@@ -30,6 +36,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: c-hive/gha-npm-cache@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
       - run: npm install
       - run: npm run build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 14
           cache: npm
-      - run: npm install
+      - run: npm ci
       - run: npm run lint
 
   test:
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 14
           cache: npm
-      - run: npm install
+      - run: npm ci
       - run: npm run test
 
   build:
@@ -40,5 +40,5 @@ jobs:
         with:
           node-version: 14
           cache: npm
-      - run: npm install
+      - run: npm ci
       - run: npm run build

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 14
           cache: npm
 
-      - run: npm install
+      - run: npm ci
 
       - run: npm run build
 

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -24,7 +24,10 @@ jobs:
 
       - uses: shabados/actions/generate-changelog@release/next
 
-      - uses: c-hive/gha-npm-cache@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
 
       - run: npm install
 

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 14
           cache: npm
 
-      - run: npm install
+      - run: npm ci
 
       - run: npm run build
 

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -26,7 +26,10 @@ jobs:
 
       - uses: shabados/actions/generate-changelog@release/next
 
-      - uses: c-hive/gha-npm-cache@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
 
       - run: npm install
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Shabad OS cross-repository GitHub actions, designed to facilitate our [release p
 - [Setup Git Identity](setup-git-identity/): sets up the Git user name and email address.
 - [Semantic Version Bump](bump-version/): figures out and bumps version based on commit history, supporting a sensible prerelease scheme.
 - [Generate Changelog](generate-changelog/): generates and commits the latest `CHANGELOG.md` based on conventional commits.
-- [Publish Branch](publish-branch/): releases the current working directory as a release branch, using the latest git tag.
+- [Publish Branch](publish-branch/): releases the current working directory as a release branch.
 - [Publish Docker](publish-docker/): Builds and publishes the supplied context to DockerHub and GitHub packages.
 - [Publish npm](publish-npm/): Publishes the current working directory to npm and GitHub packages.
-- [Publish Github](publish-github/): pushes any committed changes back to GitHub, creates a release using the latest git tag, and uploads any supplied assets to the release.
+- [Publish Github](publish-github/): pushes any committed changes back to GitHub, creates a release, and uploads any supplied assets to the release.
 
 ## Usage
 

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -4,7 +4,6 @@ import { exec } from 'child_process'
 import { promisify } from 'util'
 
 import { getInput, setFailed, info, debug, setOutput } from '@actions/core'
-import { context } from '@actions/github'
 import { inc, minor, patch, prerelease, ReleaseType } from 'semver'
 import { readJSON } from 'fs-extra'
 
@@ -88,7 +87,7 @@ const run = async () => {
   setOutput( 'has_changed', hasChanged )
 }
 
-if ( require.main === module || context.job ) {
+if ( require.main === module ) {
   run().catch( ( error: Error ) => setFailed( `Action failed with error ${error.toString()}` ) )
 }
 

--- a/generate-changelog/index.ts
+++ b/generate-changelog/index.ts
@@ -4,7 +4,6 @@ import { createWriteStream } from 'fs'
 import angularChangelog from 'conventional-changelog-angular'
 import conventionalChangelog from 'conventional-changelog'
 import { info, setFailed } from '@actions/core'
-import { context } from '@actions/github'
 import simpleGit from 'simple-git'
 
 const CHANGELOG_PATH = 'CHANGELOG.md'
@@ -35,7 +34,7 @@ const run = async () => {
   await git.commit( `docs: update changelog with v${latest} notes` )
 }
 
-if ( require.main === module || context.job ) {
+if ( require.main === module ) {
   run().catch( ( error: Error ) => setFailed( `Action failed with error ${error.toString()}` ) )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@shabados/actions",
-      "version": "1.3.1-next.0",
+      "version": "1.3.0-next.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@actions/core": "^1.2.6",
@@ -31,7 +31,7 @@
         "@types/semver": "^7.3.4",
         "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^4.1.1",
-        "@vercel/ncc": "^0.29.0",
+        "@vercel/ncc": "^0.31.1",
         "eslint": "^7.9.0",
         "eslint-config-airbnb-typescript": "^10.0.0",
         "eslint-plugin-import": "^2.22.0",
@@ -2076,9 +2076,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.29.0.tgz",
-      "integrity": "sha512-p+sB835wOSDdgm2mgFgSOcXJF84AqZ+vBEnnGS0sm8veA92Hia7sqH0qEnqeFilPl+cXtxbdh2er+WdlfbVCZA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.31.1.tgz",
+      "integrity": "sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -14653,9 +14653,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.29.0.tgz",
-      "integrity": "sha512-p+sB835wOSDdgm2mgFgSOcXJF84AqZ+vBEnnGS0sm8veA92Hia7sqH0qEnqeFilPl+cXtxbdh2er+WdlfbVCZA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.31.1.tgz",
+      "integrity": "sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==",
       "dev": true
     },
     "abab": {
@@ -18017,9 +18017,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -18385,9 +18385,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "internal-slot": {
       "version": "1.0.2",
@@ -23022,9 +23022,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/semver": "^7.3.4",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
-    "@vercel/ncc": "^0.29.0",
+    "@vercel/ncc": "^0.31.1",
     "eslint": "^7.9.0",
     "eslint-config-airbnb-typescript": "^10.0.0",
     "eslint-plugin-import": "^2.22.0",

--- a/publish-branch/index.ts
+++ b/publish-branch/index.ts
@@ -1,5 +1,4 @@
 import { setFailed, info, getInput } from '@actions/core'
-import { context } from '@actions/github'
 import { appendFile } from 'fs-extra'
 import simpleGit from 'simple-git'
 
@@ -44,7 +43,7 @@ const run = async () => {
   await git.checkout( process.env.GITHUB_REF! )
 }
 
-if ( require.main === module || context.job ) {
+if ( require.main === module ) {
   run().catch( ( error: Error ) => setFailed( `Action failed with error ${error.toString()}` ) )
 }
 

--- a/publish-github/index.ts
+++ b/publish-github/index.ts
@@ -36,7 +36,7 @@ const run = async () => {
   if ( context.eventName === 'pull_request' ) await notify( { octokit, releaseLink: html_url, version } )
 }
 
-if ( require.main === module || context.job ) {
+if ( require.main === module ) {
   run().catch( ( error: Error ) => setFailed( `Action failed with error ${error.toString()}` ) )
 }
 


### PR DESCRIPTION
### Summary of PR

CI/CD tests were failing because of `context.job` causing tests to fire twice and therefore messing with one-time mocks.

This PR removes the `context.job` entrypoint, which was only added because `require.main === module` did not work when compiled with `ncc`. This has since changed with the latest version of `ncc`, so `context.job` is no longer required.