### PR TITLE
feat(publish-github): add changelog for release to release notes

### DIFF
--- a/generate-changelog/index.ts
+++ b/generate-changelog/index.ts
@@ -6,19 +6,20 @@ import conventionalChangelog from 'conventional-changelog'
 import { info, setFailed } from '@actions/core'
 import simpleGit from 'simple-git'
 
+import { streamToPromise } from '../utils'
+
 const CHANGELOG_PATH = 'CHANGELOG.md'
 
 const generateChangelog = async () => {
-  const config = await angularChangelog
+  const writeStream = createWriteStream( CHANGELOG_PATH )
 
-  return new Promise( ( resolve, reject ) => {
-    const writeStream = createWriteStream( CHANGELOG_PATH )
-
-    conventionalChangelog( { releaseCount: 0, outputUnreleased: true, config } )
-      .pipe( writeStream )
-      .on( 'error', reject )
-      .on( 'close', resolve )
+  const changelogStream = conventionalChangelog( {
+    releaseCount: 0,
+    outputUnreleased: true,
+    config: await angularChangelog,
   } )
+
+  return streamToPromise( changelogStream.pipe( writeStream ) )
 }
 
 const run = async () => {

--- a/publish-github/README.md
+++ b/publish-github/README.md
@@ -20,11 +20,14 @@ Create a GitHub release, including commit sync, changelog inclusion, and glob-ba
 
 ### `body_path`
 
-**Required** The path to the file which will populate the contents of the release notes. Default `"CHANGELOG.md"`.
+**Required** The path to the file which will populate the contents of the release notes. If non-existent, generates the changelog for the previous release.
 
 ### `asset_paths`
 
 A newline seperated string representing a list of globs. Files which match will be uploaded to the release.
+
+### `release_version`
+**Required** The version to create the GitHub release for.
 
 ## Outputs
 

--- a/publish-github/action.yml
+++ b/publish-github/action.yml
@@ -12,13 +12,16 @@ inputs:
     default: main
 
   body_path:
-    description: The path to the file to populate the release body with
-    required: true
-    default: CHANGELOG.md
+    description: The path to the file to populate the release body with. If non-existent, generates the changelog for the previous release.
+    required: false
 
   asset_paths:
     description: Newline seperated list of globs/path to assets to be uploaded
     required: false
+
+  release_version:
+    description: The version to create the GitHub release for.
+    required: true
 
 outputs:
   id:

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './get-inputs'
+export * from './stream-to-promise'

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './get-inputs'
-export * from './stream-to-promise'
+export * from './streams'
+export * from './strings'

--- a/utils/stream-to-promise.ts
+++ b/utils/stream-to-promise.ts
@@ -1,0 +1,5 @@
+import { Stream } from 'stream'
+
+export const streamToPromise = ( stream: Stream ) => new Promise(
+  ( resolve, reject ) => stream.on( 'error', reject ).on( 'close', resolve ),
+)

--- a/utils/stream-to-promise.ts
+++ b/utils/stream-to-promise.ts
@@ -1,5 +1,0 @@
-import { Stream } from 'stream'
-
-export const streamToPromise = ( stream: Stream ) => new Promise(
-  ( resolve, reject ) => stream.on( 'error', reject ).on( 'close', resolve ),
-)

--- a/utils/streams.ts
+++ b/utils/streams.ts
@@ -1,0 +1,14 @@
+import { Stream } from 'stream'
+
+export const streamToPromise = ( stream: Stream ) => new Promise(
+  ( resolve, reject ) => stream.on( 'error', reject ).on( 'close', resolve ),
+)
+
+export const streamToString = ( stream: Stream ) => new Promise<string>( ( resolve, reject ) => {
+  const chunks = [] as Uint8Array[]
+
+  stream
+    .on( 'data', ( chunk ) => chunks.push( Buffer.from( chunk ) ) )
+    .on( 'error', ( err ) => reject( err ) )
+    .on( 'close', () => resolve( Buffer.concat( chunks ).toString( 'utf8' ) ) )
+} )

--- a/utils/strings.ts
+++ b/utils/strings.ts
@@ -1,0 +1,1 @@
+export const tail = ( string: string ) => string.slice( string.indexOf( '\n' ) + 2 )


### PR DESCRIPTION
### Summary of PR

Previously, the release body was populated via `CHANGELOG.md`. This meant that every release would display the entire changelog.

This PR generates the changelog for the release in question only, and removes the header since this is already part of the release.