### PR TITLE
feat(publish-branch): publish to next when latest is released

### DIFF
--- a/publish-branch/get-branches.ts
+++ b/publish-branch/get-branches.ts
@@ -18,6 +18,7 @@ const getBranches = async () => {
         'latest',
         `v${major( version )}`,
         `v${major( version )}.${minor( version )}`,
+        prereleaseName,
       ]
     ),
   ].map( ( suffix ) => `${prefix}/${suffix}` )

--- a/publish-branch/index.integration.spec.ts
+++ b/publish-branch/index.integration.spec.ts
@@ -78,6 +78,7 @@ describe( 'publish-branch', () => {
 
   describe( 'with releases', () => {
     it( 'should publish to the latest branch', runCase( 'v1.4.3', 'release/latest' ) )
+    it( 'should publish to the next branch', runCase( 'v1.4.3', 'release/next' ) )
     it( 'should publish to the major branch of the latest tag', runCase( 'v1.4.3', 'release/v1' ) )
     it( 'should publish to the minor branch of the latest tag', runCase( 'v1.4.3', 'release/v1.4' ) )
   } )


### PR DESCRIPTION
### Summary of PR

`next` should be released during a normal release, as this becomes the cutting-edge. Currently, `next` does not update when the version is not a pre-release, but this does not make sense.

This PR rectifies this.