### PR TITLE
ci: run CI workflow on pull request from forks or main branch push

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,10 @@
 name: Continuous Integration
 
 on:
+  pull_request:
   push:
-    branches-ignore:
-      - 'release/**'
+    branches:
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -8,39 +8,6 @@ on:
 
 jobs:
   build-publish-release:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: shabados/actions/setup-git-identity@release/next
-        with:
-          user: Shabad OS Bot
-          email: team@shabados.com
-
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: shabados/actions/bump-version@release/next
-        id: bump-version
-
-      - uses: shabados/actions/generate-changelog@release/next
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          cache: npm
-
-      - run: npm ci
-
-      - run: npm run build
-
-      - uses: shabados/actions/publish-github@release/next
-        with:
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
-          release_version: ${{ steps.bump-version.outputs.next }}
-          prerelease_branch: next
-
-      - uses: shabados/actions/publish-branch@release/next
-        with:
-          release_version: ${{ steps.bump-version.outputs.next }}
-          gitignore: |
-            !dist/
+    uses: ./github/workflows/release.yml
+    secrets:
+      GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -8,41 +8,8 @@ on:
 
 jobs:
   build-publish-release:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: shabados/actions/setup-git-identity@release/next
-        with:
-          user: Shabad OS Bot
-          email: team@shabados.com
-
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: shabados/actions/bump-version@release/next
-        id: bump-version
-        with:
-          prerelease: next
-
-      - uses: shabados/actions/generate-changelog@release/next
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          cache: npm
-
-      - run: npm ci
-
-      - run: npm run build
-
-      - uses: shabados/actions/publish-github@release/next
-        with:
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
-          release_version: ${{ steps.bump-version.outputs.next }}
-          prerelease_branch: next
-
-      - uses: shabados/actions/publish-branch@release/next
-        with:
-          release_version: ${{ steps.bump-version.outputs.next }}
-          gitignore: |
-            !dist/
+    uses: ./github/workflows/release.yml
+    with:
+      prerelease: next
+    secrets:
+      GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  workflow_call:
+    inputs:
+      prerelease:
+        required: false
+        type: string
+    secrets:
+      GH_BOT_TOKEN:
+        required: true
+
+jobs:
+  build-publish-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: shabados/actions/setup-git-identity@release/next
+        with:
+          user: Shabad OS Bot
+          email: team@shabados.com
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: shabados/actions/bump-version@release/next
+        id: bump-version
+        with:
+          prerelease: ${{ inputs.prerelease }}
+
+      - uses: shabados/actions/generate-changelog@release/next
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: shabados/actions/publish-github@release/next
+        with:
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
+          release_version: ${{ steps.bump-version.outputs.next }}
+          prerelease_branch: next
+
+      - uses: shabados/actions/publish-branch@release/next
+        with:
+          release_version: ${{ steps.bump-version.outputs.next }}
+          gitignore: |
+            !dist/

--- a/publish-github/notify.ts
+++ b/publish-github/notify.ts
@@ -4,7 +4,7 @@ type Notify = {
   octokit: ReturnType<typeof getOctokit>,
   version: string,
   releaseLink: string,
-  issueNumber: string,
+  issueNumber: number,
 }
 
 const notify = async ( { issueNumber, octokit, releaseLink, version }: Notify ) => {


### PR DESCRIPTION
### Summary of PR

Currently, the CI flow is only run on push. This does not work for PRs that are forks.

This changes this behaviour to allow for `main` to be built with the CI flow, and `pull_request` to do the same.

This PR also adds reusable workflows for releases.