### PR TITLE
feat(publish-branches): update prerelease branch if supplied

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           release_version: ${{ steps.bump-version.outputs.next }}
+          prerelease_branch: next
 
       - uses: shabados/actions/publish-branch@release/next
         with:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           release_version: ${{ steps.bump-version.outputs.next }}
+          prerelease_branch: next
 
       - uses: shabados/actions/publish-branch@release/next
         with:

--- a/publish-branch/action.yml
+++ b/publish-branch/action.yml
@@ -15,6 +15,10 @@ inputs:
     required: true
     default: release
 
+  prerelease_branch:
+    description: The name of the prerelease branch. e.g. `next`.
+    required: false
+
   gitignore:
     description: The contents to append to the existing `.gitignore`. This is useful to exclude patterns that are normally included in the `.gitignore` file, with the `!` negation operator.
     default: ''

--- a/publish-branch/get-branches.ts
+++ b/publish-branch/get-branches.ts
@@ -8,17 +8,22 @@ const getBranches = async () => {
   // Get latest version through input
   const version = getInput( 'release_version' )
 
+  // Optionally get the name of the prerelease branch
+  const prereleaseBranch = getInput( 'prerelease_branch' )
+
   const [ prereleaseName ] = prerelease( version ) || []
 
   return [
     version,
     ...( prereleaseName
-      ? [ prereleaseName ]
+      // Use the supplied prerelease branch name, otherwise extract it from the version
+      ? [ prereleaseBranch ?? prereleaseName ]
       : [
         'latest',
         `v${major( version )}`,
         `v${major( version )}.${minor( version )}`,
-        prereleaseName,
+        // If defined, update the prerelease branch
+        ...( prereleaseBranch ? [ prereleaseBranch ] : [] ),
       ]
     ),
   ].map( ( suffix ) => `${prefix}/${suffix}` )

--- a/publish-branch/index.integration.spec.ts
+++ b/publish-branch/index.integration.spec.ts
@@ -20,7 +20,7 @@ const runCase = (
   expectedBranch: string,
   { fixedBranch = '' }: CaseOptions = {},
 ) => async () => {
-  setWith( { fixed_branch: fixedBranch, release_version: tag } )
+  setWith( { fixed_branch: fixedBranch, release_version: tag, prerelease_branch: 'beta' } )
 
   // Create repo in temporary path
   const path = resolve( TMP_PATH, v4() )
@@ -78,7 +78,7 @@ describe( 'publish-branch', () => {
 
   describe( 'with releases', () => {
     it( 'should publish to the latest branch', runCase( 'v1.4.3', 'release/latest' ) )
-    it( 'should publish to the next branch', runCase( 'v1.4.3', 'release/next' ) )
+    it( 'should publish to the prerelease branch', runCase( 'v1.4.3', 'release/beta' ) )
     it( 'should publish to the major branch of the latest tag', runCase( 'v1.4.3', 'release/v1' ) )
     it( 'should publish to the minor branch of the latest tag', runCase( 'v1.4.3', 'release/v1.4' ) )
   } )


### PR DESCRIPTION
### Summary of PR

Previously, the prerelease branch was inferred from a prerelease version. This means that it was not possible to update the prerelease branch if the supplied version was a release version.

This PR adds a parameter to allow for specifying and updating a specific prerelease branch name when the latest release happens, and also when the prerelease happens.
