### PR TITLE
ci: reference repository in reusable release workflow

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   build-publish-release:
-    uses: .github/workflows/release.yml@main
+    uses: shabados/actions/.github/workflows/release.yml@main
     secrets:
       GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-publish-release:
-    uses: .github/workflows/release.yml@main
+    uses: shabados/actions/.github/workflows/release.yml@main
     with:
       prerelease: next
     secrets:


### PR DESCRIPTION
### Summary of PR
Referencing the repo directly is required with reusable workflows