### PR TITLE
feat: add integrate commits action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build-publish-release:
     runs-on: ubuntu-20.04
+    concurrency: release
     steps:
       - uses: shabados/actions/setup-git-identity@release/next
         with:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Shabad OS cross-repository GitHub actions, designed to facilitate our [release p
 - [Setup Git Identity](setup-git-identity/): sets up the Git user name and email address.
 - [Semantic Version Bump](bump-version/): figures out and bumps version based on commit history, supporting a sensible prerelease scheme.
 - [Generate Changelog](generate-changelog/): generates and commits the latest `CHANGELOG.md` based on conventional commits.
+- [Integrate Commits](integrate-commits/): integrates commits made by CI into the main branch by pushing and building them to an integration branch and merging when the checks go green.
 - [Publish Branch](publish-branch/): releases the current working directory as a release branch.
 - [Publish Docker](publish-docker/): Builds and publishes the supplied context to DockerHub and GitHub packages.
 - [Publish npm](publish-npm/): Publishes the current working directory to npm and GitHub packages.

--- a/integrate-commits/README.md
+++ b/integrate-commits/README.md
@@ -1,0 +1,19 @@
+# Integrate commits Action
+
+Integrates commits back into the main branch by pushing commits to an integration branch, waiting for the commits to pass any status checks, and then merging into the main branch.
+
+This allows for confidence when re-integrating commits made by CI or release processes back into the main branch.
+
+## Inputs
+
+### `main_branch`
+
+**Required** The name of the main branch to push commits to.
+
+### `integration_branch`
+
+**Requred** The branch to push commits to and build before merging into the main branch.
+
+```yaml
+uses: shabados/actions/integrate-commits@release/v1
+```

--- a/integrate-commits/action.yml
+++ b/integrate-commits/action.yml
@@ -1,0 +1,30 @@
+name: Integrate Commits
+
+description: Integrate commits back into the main branch by building on a side-branch and passing status checks.
+
+inputs:
+  main_branch:
+    required: true
+    default: main
+    description: The name of the main branch to push commits to.
+
+  integration_branch:
+    required: true
+    default: integration
+    description: The branch to push commits to and build before merging into the main branch.
+
+runs:
+  using: composite
+  steps:
+    - name: Push to integration branch
+      run: git push origin ${{ inputs.integration_branch }}
+
+    - uses: WyriHaximus/github-action-wait-for-status@v2
+      id: status-checks
+
+    - name: Push to main branch
+      if: steps.status-checks.outputs.status == 'success'
+      run: |
+        git checkout ${{ inputs.main_branch }}
+        git merge ${{ inputs.integration_branch }}
+        git push ${{ inputs.main_branch}} --follow-tags

--- a/publish-github/index.ts
+++ b/publish-github/index.ts
@@ -9,7 +9,7 @@ import uploadAssets from './upload-assets'
 const git = simpleGit()
 
 const run = async () => {
-  // Push to main branch
+  // Push to main branch - REMOVE THIS
   const branch = getInput( 'main_branch' )
   info( `Pushing to ${branch}` )
   await git.push( 'origin', branch, { '--follow-tags': null } )


### PR DESCRIPTION
### Summary of PR

Since commits are added by CI/CD for version bumps, changelogs, and potentially release notes in the future, a re-integration of commits action has been added:

- Create an integration branch
- Push commits from the release there
- Wait for the green light
- Merge to main branch