### PR TITLE
ci: add integrate-commits step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
 
       - run: npm run build
 
+      - uses: shabados/actions/integrate-commits@release/next
+
       - uses: shabados/actions/publish-github@release/next
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Shabad OS cross-repository GitHub actions, designed to facilitate our [release p
 - [Publish Branch](publish-branch/): releases the current working directory as a release branch.
 - [Publish Docker](publish-docker/): Builds and publishes the supplied context to DockerHub and GitHub packages.
 - [Publish npm](publish-npm/): Publishes the current working directory to npm and GitHub packages.
-- [Publish Github](publish-github/): pushes any committed changes back to GitHub, creates a release, and uploads any supplied assets to the release.
+- [Publish Github](publish-github/): Creates a GitHub release, and uploads any supplied assets to the release.
 
 ## Usage
 

--- a/publish-github/README.md
+++ b/publish-github/README.md
@@ -2,7 +2,6 @@
 
 Create a GitHub release, including commit sync, changelog inclusion, and glob-based asset uploading.
 
-- Pushes any commits and tags back to the `main` branch
 - Creates a GitHub release using latest git tag
 - If changelog present, publish it as release notes in the release
 - Upload any assets matching the globs supplied

--- a/publish-github/index.integration.spec.ts
+++ b/publish-github/index.integration.spec.ts
@@ -4,7 +4,7 @@ import { chdir } from 'process'
 import { mkdirp, writeFile } from 'fs-extra'
 import nock from 'nock'
 import { v4 } from 'uuid'
-import { SimpleGit } from 'simple-git'
+import simpleGit from 'simple-git'
 
 import { setWith } from '../test/utils'
 
@@ -25,30 +25,9 @@ const nockUploadAsset = ( releaseId: number, name: string ) => nock( 'https://up
   .post( `/repos/${process.env.GITHUB_REPOSITORY!}/releases/${releaseId}/assets?name=${name}&` )
   .reply( 200 )
 
-const simpleGit = jest.requireActual<( path: string ) => SimpleGit>( 'simple-git' )
-
-const gitMock = {
-  push: jest.fn(),
-}
-
-jest.mock( 'simple-git', () => () => gitMock )
-
 const TMP_PATH = join( __dirname, 'tmp' )
 
 describe( 'publish-github', () => {
-  describe( 'when pushing', () => {
-    it( 'should push the contents of the directory to the main branch', async () => {
-      const testBranch = 'test'
-      setWith( { main_branch: testBranch } )
-
-      nockCreateRelease()
-
-      await run()
-
-      expect( gitMock.push ).toHaveBeenCalledWith( 'origin', testBranch, { '--follow-tags': null } )
-    } )
-  } )
-
   describe( 'when creating a release', () => {
     it( 'should create a release with the supplied release version', async () => {
       const releaseVersion = 'v1.3.0'

--- a/publish-github/index.ts
+++ b/publish-github/index.ts
@@ -1,19 +1,11 @@
 
 import { getInput, setFailed, info, setOutput } from '@actions/core'
 import { getOctokit } from '@actions/github'
-import simpleGit from 'simple-git'
 
 import createRelease from './create-release'
 import uploadAssets from './upload-assets'
 
-const git = simpleGit()
-
 const run = async () => {
-  // Push to main branch - REMOVE THIS
-  const branch = getInput( 'main_branch' )
-  info( `Pushing to ${branch}` )
-  await git.push( 'origin', branch, { '--follow-tags': null } )
-
   // Get octokit instance
   const token = getInput( 'github_token' ) || process.env.github_token! || process.env.GITHUB_TOKEN!
   const octokit = getOctokit( token )


### PR DESCRIPTION
### Summary of PR

Removes git usage in publish-github action and moves it all to the new `ingrate-commits` action.