### PR TITLE
fix(integrate-commits): create upstream integration branch

### DIFF
--- a/integrate-commits/action.yml
+++ b/integrate-commits/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Push to integration branch
       shell: bash
-      run: git push origin ${{ inputs.integration_branch }}
+      run: git push -u origin ${{ inputs.integration_branch }}
 
     - uses: WyriHaximus/github-action-wait-for-status@v1.4.0
 


### PR DESCRIPTION
## Summary

The upstream integration branch does not always exist - in these cases, the push fails. This PR adds the `-u` flag to create the upstream branch.