### PR TITLE
fix(bump-version): remove build skip from commit message

### DIFF
--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -79,7 +79,7 @@ const run = async () => {
   if ( hasChanged ) {
     // Run npm version [version] with custom commit message
     info( `Bumping ${current} to ${version}` )
-    await asyncExec( `npm version ${version} -m "build: bump to v${version}\n\n[skip ci]"` )
+    await asyncExec( `npm version ${version} -m "build: bump to v${version}"` )
   }
 
   setOutput( 'previous', current )


### PR DESCRIPTION
### Summary of PR

The commit message for the version bump contains [skip ci], which I suspect prevents the `integration` branch from building.

This PR removes this.
