### PR TITLE
ci: use custom token for pushing during release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_BOT_TOKEN }}
 
       - uses: shabados/actions/bump-version@release/next
         id: bump-version


### PR DESCRIPTION
When using GitHub's supplied PAT set up in the checkout step, new workflows cannot be triggered through a push.

Instead, the bot token has been supplied.

See https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/7.