### PR TITLE
fix(wait-for-green): report the number of seconds, not milliseconds

### DIFF
--- a/integrate-commits/action.yml
+++ b/integrate-commits/action.yml
@@ -33,5 +33,5 @@ runs:
       shell: bash
       run: |
         git checkout ${{ inputs.main_branch }}
-        git merge ${{ inputs.integration_branch }}
-        git push ${{ inputs.main_branch}} --follow-tags
+        git merge origin/${{ inputs.integration_branch }}
+        git push origin ${{ inputs.main_branch}} --follow-tags

--- a/wait-for-green/index.ts
+++ b/wait-for-green/index.ts
@@ -15,7 +15,7 @@ const pollUntil = (
 } )
 
 const run = async () => {
-  const interval = Number( getInput( 'interval' ) ) * 1000
+  const interval = Number( getInput( 'interval' ) )
   const ref = getInput( 'ref' )
 
   // Get octokit instance
@@ -34,7 +34,7 @@ const run = async () => {
 
       return status === 'completed' && conclusion === 'success'
     } )
-  }, interval )
+  }, interval * 1000 )
 }
 
 if ( require.main === module ) {


### PR DESCRIPTION
### Summary of PR

- Report the poll interval in seconds, not milliseconds
- Correctly merge the integration branch