### PR TITLE
fix(publish-branches): filter null release branches out

### DIFF
--- a/publish-branch/get-branches.ts
+++ b/publish-branch/get-branches.ts
@@ -1,6 +1,12 @@
 import { getInput } from '@actions/core'
 import { major, minor, prerelease } from 'semver'
 
+const getReleaseBranches = ( version: string ) => [
+  'latest',
+  `v${major( version )}`,
+  `v${major( version )}.${minor( version )}`,
+]
+
 // Enumerate the release branches to push to
 const getBranches = async () => {
   const prefix = getInput( 'release_branch_prefix' )
@@ -8,25 +14,23 @@ const getBranches = async () => {
   // Get latest version through input
   const version = getInput( 'release_version' )
 
-  // Optionally get the name of the prerelease branch
-  const prereleaseBranch = getInput( 'prerelease_branch' )
+  const [ prereleaseName ] = prerelease( version ) ?? []
 
-  const [ prereleaseName ] = prerelease( version ) || []
+  // Use the supplied prerelease branch name, otherwise extract it from the version
+  const prereleaseBranch = getInput( 'prerelease_branch' ) || prereleaseName
+
+  const isRelease = !prereleaseName
 
   return [
     version,
-    ...( prereleaseName
-      // Use the supplied prerelease branch name, otherwise extract it from the version
-      ? [ prereleaseBranch ?? prereleaseName ]
-      : [
-        'latest',
-        `v${major( version )}`,
-        `v${major( version )}.${minor( version )}`,
-        // If defined, update the prerelease branch
-        ...( prereleaseBranch ? [ prereleaseBranch ] : [] ),
-      ]
-    ),
-  ].map( ( suffix ) => `${prefix}/${suffix}` )
+    // Always update the prerelease branch, if supplied
+    prereleaseBranch,
+    ...( isRelease ? getReleaseBranches( version ) : [] ),
+  ]
+    // Remove any falsy values
+    .filter( ( x ) => x )
+    // Add release prefix
+    .map( ( suffix ) => `${prefix}/${suffix}` )
 }
 
 export default getBranches


### PR DESCRIPTION
### Summary of PR

To prevent

```
Appending to .gitignore
Creating release/1.5.0-next.1
Creating release/
Updating release/
```

where `release/[missing branch here]`