### PR TITLE
ci: supply prerelease_branch to publish-branch instead of publish-github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           release_version: ${{ steps.bump-version.outputs.next }}
-          prerelease_branch: next
 
       - uses: shabados/actions/publish-branch@release/next
         with:
+          prerelease_branch: next
           release_version: ${{ steps.bump-version.outputs.next }}
           gitignore: |
             !dist/


### PR DESCRIPTION
### Summary of PR

The `prerelease_branch` input was supplied to the wrong action - this fixes this.