### PR TITLE
fix: fix GitHub publish release

### DIFF
--- a/utils/streams.ts
+++ b/utils/streams.ts
@@ -10,5 +10,5 @@ export const streamToString = ( stream: Stream ) => new Promise<string>( ( resol
   stream
     .on( 'data', ( chunk ) => chunks.push( Buffer.from( chunk ) ) )
     .on( 'error', ( err ) => reject( err ) )
-    .on( 'close', () => resolve( Buffer.concat( chunks ).toString( 'utf8' ) ) )
+    .on( 'end', () => resolve( Buffer.concat( chunks ).toString( 'utf8' ) ) )
 } )


### PR DESCRIPTION
### Summary of PR

The `close` event in `streamToString` caused GitHub actions to silently fail and pass the step without completion. Using the `end` event seems to fix this...