### PR TITLE
fix(publish-branch): ensure v prefix is on exact version branch

### DIFF
--- a/publish-branch/get-branches.ts
+++ b/publish-branch/get-branches.ts
@@ -22,7 +22,7 @@ const getBranches = async () => {
   const isRelease = !prereleaseName
 
   return [
-    version,
+    `v${version}`,
     // Always update the prerelease branch, if supplied
     prereleaseBranch,
     ...( isRelease ? getReleaseBranches( version ) : [] ),

--- a/publish-branch/index.integration.spec.ts
+++ b/publish-branch/index.integration.spec.ts
@@ -16,11 +16,11 @@ type CaseOptions = {
 }
 
 const runCase = (
-  tag: string,
+  version: string,
   expectedBranch: string,
   { fixedBranch = '' }: CaseOptions = {},
 ) => async () => {
-  setWith( { fixed_branch: fixedBranch, release_version: tag, prerelease_branch: 'beta' } )
+  setWith( { fixed_branch: fixedBranch, release_version: version, prerelease_branch: 'beta' } )
 
   // Create repo in temporary path
   const path = resolve( TMP_PATH, v4() )
@@ -43,7 +43,7 @@ const runCase = (
   await remoteGit
     .init()
     .add( '-A' )
-    .commit( `build: release ${tag}` )
+    .commit( `build: release ${version}` )
 
   // Clone simulated remote repository into local repository
   await localGit.clone( remotePath, localPath )
@@ -63,23 +63,23 @@ const runCase = (
 jest.setTimeout( 1000 * 10 )
 
 describe( 'publish-branch', () => {
-  it( 'should publish to a release branch of the latest tag', runCase( 'v1.4.3', 'release/v1.4.3' ) )
+  it( 'should publish to a release branch of the latest tag', runCase( '1.4.3', 'release/v1.4.3' ) )
 
   it( 'should publish to a release branch of the latest tag, given previous releases', async () => {
-    await runCase( 'v1.4.3', 'release/v1.4.3' )()
-    await runCase( 'v1.4.4', 'release/v1.4.4' )()
+    await runCase( '1.4.3', 'release/v1.4.3' )()
+    await runCase( '1.4.4', 'release/v1.4.4' )()
   } )
 
-  it( 'should publish to a fixed branch, given an input with a fixed branch name', runCase( 'v1.4.3', 'gh-pages', { fixedBranch: 'gh-pages' } ) )
+  it( 'should publish to a fixed branch, given an input with a fixed branch name', runCase( '1.4.3', 'gh-pages', { fixedBranch: 'gh-pages' } ) )
 
   describe( 'with prereleases', () => {
-    it( 'should publish to the latest prerelease branch', runCase( 'v1.4.3-beta.4', 'release/beta' ) )
+    it( 'should publish to the latest prerelease branch', runCase( '1.4.3-beta.4', 'release/beta' ) )
   } )
 
   describe( 'with releases', () => {
-    it( 'should publish to the latest branch', runCase( 'v1.4.3', 'release/latest' ) )
-    it( 'should publish to the prerelease branch', runCase( 'v1.4.3', 'release/beta' ) )
-    it( 'should publish to the major branch of the latest tag', runCase( 'v1.4.3', 'release/v1' ) )
-    it( 'should publish to the minor branch of the latest tag', runCase( 'v1.4.3', 'release/v1.4' ) )
+    it( 'should publish to the latest branch', runCase( '1.4.3', 'release/latest' ) )
+    it( 'should publish to the prerelease branch', runCase( '1.4.3', 'release/beta' ) )
+    it( 'should publish to the major branch of the latest tag', runCase( '1.4.3', 'release/v1' ) )
+    it( 'should publish to the minor branch of the latest tag', runCase( '1.4.3', 'release/v1.4' ) )
   } )
 } )


### PR DESCRIPTION
### Summary of PR
similar to #79, the `v` prefix was not added to the latest version of the release branch, so we ended up with:

```
release/1.5.1
release/v1.5
release/v1
release/latest
release/next
```
 
which is a little annoying... fixed!