### PR TITLE
feat(bump-version): read current version from git tags

### DIFF
--- a/bump-version/index.integration.spec.ts
+++ b/bump-version/index.integration.spec.ts
@@ -48,6 +48,7 @@ const runCase = ( prereleaseBranch = '' ) => async (
     .init()
     .add( packagePath )
     .commit( `build: release v${from}` )
+    .addTag( `v${from}` )
 
   // Apply each commit
   const options: Options = { '--allow-empty': null }


### PR DESCRIPTION
### Summary of PR
Bump version now reads current version from git tags (date descending) instead of package.json.

### Linked issues
Related #84 
