### PR TITLE
fix(bump-version): use creatordate instead of taggerdate to get version

### DIFF
--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -65,7 +65,7 @@ const run = async () => {
   info( `${reason} ${isPrerelease ? `and is a ${prereleaseId} prerelease` : ''}` )
 
   // Get current version from git tag
-  const [ current ] = ( await SimpleGit().tag( { '--sort': '-taggerdate' } ) ).split( '\n' )
+  const [ current ] = ( await SimpleGit().tag( { '--sort': '-creatordate' } ) ).split( '\n' )
 
   // Get new version based on next release information
   const version = increment( current, releaseType as ReleaseType, isPrerelease, prereleaseId )


### PR DESCRIPTION
### Summary of PR

Uses creatordate instead of taggerdate in sorting the git tags in bump-version. This should prevent the latest tags from not being present if they're not off mainline.

Fixes #88 
