### PR TITLE
fix(bump-version): provide fallback version when no git tags are present

### DIFF
--- a/bump-version/index.integration.spec.ts
+++ b/bump-version/index.integration.spec.ts
@@ -27,7 +27,10 @@ const commitMessages = {
  * Runs each test case.
  * Creates a fresh repo and applies the commits.
  */
-const runCase = ( prereleaseBranch = '' ) => async (
+const runCase = ( {
+  prereleaseBranch = '',
+  hasInitialTag = true,
+} = {} ) => async (
   from: string,
   to: string,
   commits: CommitType[],
@@ -48,7 +51,8 @@ const runCase = ( prereleaseBranch = '' ) => async (
     .init()
     .add( packagePath )
     .commit( `build: release v${from}` )
-    .addTag( `v${from}` )
+
+  if ( hasInitialTag ) await git.addTag( `v${from}` )
 
   // Apply each commit
   const options: Options = { '--allow-empty': null }
@@ -111,9 +115,9 @@ describe( 'bump-version', () => {
       [ '1.1.1', '2.0.0-next.0', [ CommitType.breaking ] ],
     ]
 
-    it.each( cases )( 'should bump %s to %s, given a %p in commit history', runCase( 'next' ) )
+    it.each( cases )( 'should bump %s to %s, given a %p in commit history', runCase( { prereleaseBranch: 'next' } ) )
 
-    it( 'should bump with any prerelease prefix, given a commit history', () => runCase( 'beta' )( '1.0.0', '1.0.1-beta.0', [ CommitType.fix ] ) )
+    it( 'should bump with any prerelease prefix, given a commit history', () => runCase( { prereleaseBranch: 'beta' } )( '1.0.0', '1.0.1-beta.0', [ CommitType.fix ] ) )
   } )
 
   describe( 'from next release -> next release', () => {
@@ -128,6 +132,17 @@ describe( 'bump-version', () => {
       [ '2.0.0-next.0', '2.0.0-next.1', [ CommitType.fix ] ],
     ]
 
-    it.each( cases )( 'should bump %s to %s, given a %p in commit history', runCase( 'next' ) )
+    it.each( cases )( 'should bump %s to %s, given a %p in commit history', runCase( { prereleaseBranch: 'next' } ) )
+  } )
+
+  describe( 'from no release -> next release', () => {
+    type TestCase = [string, CommitType[], string?]
+
+    const cases: TestCase[] = [
+      [ '1.0.0', [ CommitType.breaking ] ],
+      [ '1.0.0-next.0', [ CommitType.breaking ], 'next' ],
+    ]
+
+    it.each( cases )( 'should bump to %s, given a %p in commit history and no existing version git tag', ( to, commits, prereleaseBranch = '' ) => runCase( { prereleaseBranch, hasInitialTag: false } )( '0.0.1', to, commits ) )
   } )
 } )


### PR DESCRIPTION
Allows for action to work in fresh repositories.

Fixes #91
